### PR TITLE
Update python versions in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 python:
+- '2.7'
 - '3.4'
+- '3.5'
 install:
 - pip install -r requirements.txt
 script: coverage run membersuite-api-client/tests.py


### PR DESCRIPTION
To include 2.7 and 3.5 (as well as 3.4).

Need to support python 2.7 because aashe-auth is going to depend on python-membersuite-api-client, and aashe-auth is used by apps running on 2.7.

