### PR TITLE
Mod ConciergeClient API

### DIFF
--- a/membersuite-api-client/client.py
+++ b/membersuite-api-client/client.py
@@ -1,53 +1,46 @@
-import os
-import hmac
-from hashlib import sha1
-import base64
 from datetime import datetime
-from zeep import Client
+from hashlib import sha1
 from lxml import etree
-
-_MS_ACCESS_KEY = os.environ.get('MS_ACCESS_KEY', None)
-_MS_SECRET_KEY = os.environ.get('MS_SECRET_KEY', None)
-_MS_ASSOCIATION_ID = os.environ.get('MS_ASSOCIATION_ID', None)
-_MS_USER_ID = os.environ.get('MS_USER_ID', None)
-_MS_USER_PASS = os.environ.get('MS_USER_PASS', None)
+from zeep import Client
+import base64
+import hmac
+import os
 
 XHTML_NAMESPACE = "http://membersuite.com/schemas"
 
 
-class ConciergeClient:
+class LoginToPortalError(Exception):
 
-    def __init__(self):
+    pass
+
+
+class MembersuiteLoginError(Exception):
+
+    pass
+
+
+class ConciergeClient(object):
+
+    def __init__(self, username, password, access_key, secret_key,
+                 association_id):
         """
         Initializes Client object by pulling in authentication credentials.
         Altered to make "request_session" a manual call to facilitate testing.
         """
-        if not _MS_ACCESS_KEY:
-            raise Exception('No MemberSuite Access Key provided.')
-        if not _MS_SECRET_KEY:
-            raise Exception('No MemberSuite Secret Key provided.')
-        if not _MS_ASSOCIATION_ID:
-            raise Exception('No MemberSuite Association ID provided.')
+        self.username = username
+        self.password = password
+        self.access_key = access_key
+        self.secret_key = secret_key
+        self.association_id = association_id
+        self.session_id = None
         self.client = Client('https://soap.membersuite.com/mex')
-        self.access_key = _MS_ACCESS_KEY
-        self.secret_key = _MS_SECRET_KEY
-        self.association_id = _MS_ASSOCIATION_ID
 
-        self.url = \
-            "http://membersuite.com/contracts/IConciergeAPIService/Login"
-        self.session_id = None
-        self.hashed_signature = self.get_hashed_signature()
-        self.session_id = None
-        self.session_start_time = datetime.now()
 
-    def get_hashed_signature(self):
+    def get_hashed_signature(self, url):
         """
         Process from Membersuite Docs: http://bit.ly/2eSIDxz
-
-        Usage: Modify self.url attribute of class
-               before calling method, if necessary
         """
-        data = "%s%s" % (self.url, self.association_id)
+        data = "%s%s" % (url, self.association_id)
         if self.session_id:
             data = "%s%s" % (data, self.session_id)
         data_b = bytearray(data, 'utf-8')
@@ -63,24 +56,24 @@ class ConciergeClient:
         necessary to construct all future requests.
         :return: Session ID to be placed in header of all other requests.
         """
-
-        concierge_request_header = self.construct_concierge_header()
+        concierge_request_header = self.construct_concierge_header(
+            url="http://membersuite.com/contracts/IConciergeAPIService/Login")
 
         result = self.client.service.Login(
             _soapheaders=[concierge_request_header],
-            userName=_MS_USER_ID,
-            password=_MS_USER_PASS,
-            loginDestination=_MS_ASSOCIATION_ID
+            userName=self.username,
+            password=self.password,
+            loginDestination=self.association_id,
         )
 
         try:
             self.session_id = result['header']['header']['SessionId']
-        except:
-            pass
+        except Exception as exc:
+            raise MembersuiteLoginError(exc)
 
         return self.session_id
 
-    def construct_concierge_header(self):
+    def construct_concierge_header(self, url):
         """
         Constructs the Concierge Request Header lxml object to be used as the
         '_soapheaders' argument for WSDL methods.
@@ -99,16 +92,40 @@ class ConciergeClient:
         access_key = \
             etree.SubElement(concierge_request_header,
                              etree.QName(XHTML_NAMESPACE, "AccessKeyId"))
-        access_key.text = _MS_ACCESS_KEY
+        access_key.text = self.access_key
 
         association_id = \
             etree.SubElement(concierge_request_header,
                              etree.QName(XHTML_NAMESPACE, "AssociationId"))
-        association_id.text = _MS_ASSOCIATION_ID
+        association_id.text = self.association_id
 
         signature = \
             etree.SubElement(concierge_request_header,
                              etree.QName(XHTML_NAMESPACE, "Signature"))
-        signature.text = self.hashed_signature
+        signature.text = self.get_hashed_signature(url=url)
 
         return concierge_request_header
+
+    def login_to_portal(self, username, password):
+        """Logs `username` into the MemberSuite Portal.
+
+        This could go into aashe-auth instead of here.
+        """
+        if not self.session_id:
+            self.request_session()
+
+        concierge_request_header = self.construct_concierge_header(
+            url="http://membersuite.com/path/to/LoginToPortal")
+
+        result = self.client.service.LoginToPortal(
+            _soapheaders=[concierge_request_header],
+            userName=self.username,
+            password=self.password,
+            loginDestination=self.association_id,
+            magicArgsToPassUsernameAndPasswordToLoginWith=(username,
+                                                           password))
+
+        if magic_test_of_result():
+            return membersuite_security_token_or_something_like_that
+        else:
+            raise LoginToPortalError(result["interesting magic bits"])

--- a/membersuite-api-client/tests.py
+++ b/membersuite-api-client/tests.py
@@ -1,5 +1,14 @@
+import os
 import unittest
+
 from client import ConciergeClient
+
+
+TEST_USERNAME = os.environ["TEST_USERNAME"]
+TEST_PASSWORD = os.environ["TEST_PASSWORD"]
+TEST_ACCESS_KEY = os.environ["TEST_ACCESS_KEY"]
+TEST_SECRET_KEY = os.environ["TEST_SECRET_KEY"]
+TEST_ASSOCIATION_ID = os.environ["TEST_ASSOCIATION_ID"]
 
 
 class ConciergeClientTestCase(unittest.TestCase):
@@ -8,42 +17,51 @@ class ConciergeClientTestCase(unittest.TestCase):
         """
         Tests that we are properly hashing the signature data
         """
-        # Instantiate Client and check that it was successful.
-        test_client = ConciergeClient()
-        self.assertTrue(test_client)
+        client = ConciergeClient(
+            username=TEST_USERNAME,
+            password=TEST_PASSWORD,
+            access_key=TEST_ACCESS_KEY,
+            secret_key=("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+                        "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="),
+            association_id="00000000-0000-0000-0000-000000000000")
 
         # Modify attributes to use sample data from API docs
         # to test that signature is hashed properly.
-        test_client.url = "http://membersuite.com/contracts/IConciergeAPIService/WhoAmI"
-        test_client.secret_key = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="
-        test_client.association_id = "00000000-0000-0000-0000-000000000000"
-        test_client.session_id = "11111111-1111-1111-1111-111111111111"
-        signature = test_client.get_hashed_signature()
+        client.session_id = "11111111-1111-1111-1111-111111111111"
+        signature = client.get_hashed_signature(
+            url="http://membersuite.com/contracts/IConciergeAPIService/WhoAmI")
         self.assertEqual(signature, "2zsMYdHb/MJUeTjv5cQl5pBuIqU=")
 
-    def test_create_session(self):
+    def test_request_session(self):
         """
-        Tests that with your credentials saved to proper env vars the client
-        can send a login request and receive a session ID.
+        Can we send a login request and receive a session ID?
         """
-        # Instantiate Client and check that it was successful.
-        test_client = ConciergeClient()
-        self.assertTrue(test_client)
+        client = ConciergeClient(username=TEST_USERNAME,
+                                 password=TEST_PASSWORD,
+                                 access_key=TEST_ACCESS_KEY,
+                                 secret_key=TEST_SECRET_KEY,
+                                 association_id=TEST_ASSOCIATION_ID)
 
         # Send a login request to receive a session id
-        session_id = test_client.request_session()
+        session_id = client.request_session()
         self.assertTrue(session_id)
 
-        # Invoke the ListAllReports method to test usage of the received session ID
-        test_client.url = "http://membersuite.com/contracts/IConciergeAPIService/ListAllReports"
-        test_client.hashed_signature = test_client.get_hashed_signature()
-        concierge_request_header = test_client.construct_concierge_header()
-        response = test_client.client.service.ListAllReports(_soapheaders=[concierge_request_header])
+        # Invoke the ListAllReports method to test usage of the
+        # received session ID
+        url = ("http://membersuite.com/contracts/"
+               "IConciergeAPIService/ListAllReports")
+        client.hashed_signature = client.get_hashed_signature(url=url)
+        concierge_request_header = client.construct_concierge_header(url=url)
+        response = client.client.service.ListAllReports(
+            _soapheaders=[concierge_request_header])
 
         # Check that the session ID in the response headers matches the
         # previously obtained session, so the user was not re-authenticated
         # but properly used the established session.
-        self.assertEqual(response['header']['header']['SessionId'], test_client.session_id)
+        self.assertEqual(
+            client.get_session_id_from_login_result(login_result=response),
+            client.session_id)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/membersuite-api-client/tests.py
+++ b/membersuite-api-client/tests.py
@@ -4,11 +4,11 @@ import unittest
 from client import ConciergeClient
 
 
-TEST_USERNAME = os.environ["TEST_USERNAME"]
-TEST_PASSWORD = os.environ["TEST_PASSWORD"]
-TEST_ACCESS_KEY = os.environ["TEST_ACCESS_KEY"]
-TEST_SECRET_KEY = os.environ["TEST_SECRET_KEY"]
-TEST_ASSOCIATION_ID = os.environ["TEST_ASSOCIATION_ID"]
+MS_USER_ID = os.environ["MS_USER_ID"]
+MS_USER_PASS = os.environ["MS_USER_PASS"]
+MS_ACCESS_KEY = os.environ["MS_ACCESS_KEY"]
+MS_SECRET_KEY = os.environ["MS_SECRET_KEY"]
+MS_ASSOCIATION_ID = os.environ["MS_ASSOCIATION_ID"]
 
 
 class ConciergeClientTestCase(unittest.TestCase):
@@ -18,9 +18,9 @@ class ConciergeClientTestCase(unittest.TestCase):
         Tests that we are properly hashing the signature data
         """
         client = ConciergeClient(
-            username=TEST_USERNAME,
-            password=TEST_PASSWORD,
-            access_key=TEST_ACCESS_KEY,
+            username=MS_USER_ID,
+            password=MS_USER_PASS,
+            access_key=MS_ACCESS_KEY,
             secret_key=("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
                         "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="),
             association_id="00000000-0000-0000-0000-000000000000")
@@ -36,11 +36,11 @@ class ConciergeClientTestCase(unittest.TestCase):
         """
         Can we send a login request and receive a session ID?
         """
-        client = ConciergeClient(username=TEST_USERNAME,
-                                 password=TEST_PASSWORD,
-                                 access_key=TEST_ACCESS_KEY,
-                                 secret_key=TEST_SECRET_KEY,
-                                 association_id=TEST_ASSOCIATION_ID)
+        client = ConciergeClient(username=MS_USER_ID,
+                                 password=MS_USER_PASS,
+                                 access_key=MS_ACCESS_KEY,
+                                 secret_key=MS_SECRET_KEY,
+                                 association_id=MS_ASSOCIATION_ID)
 
         # Send a login request to receive a session id
         session_id = client.request_session()


### PR DESCRIPTION
Take secrets as arguments rather than pulling directly from the environment.

Summary of changes:
* `ConciergeClient.__init__()` requires the following new arguments;  
  - `username`
  - `password`
  - `access_key`
  - `secret_key`
  - `association_id`
* `ConciergeClient` methods `get_hashed_signature` and `construct_concierge_header` require a new argument, `url`.