### PR TITLE
Add Object Conversion Method

### DIFF
--- a/membersuite-api-client/client.py
+++ b/membersuite-api-client/client.py
@@ -129,9 +129,18 @@ class ConciergeClient(object):
             msqlStatement=query,
             startRecord=0
         )
-
         if result["body"]["ExecuteMSQLResult"]["ResultValue"]["ObjectSearchResult"]["Objects"]:
             return(result["body"]["ExecuteMSQLResult"]["ResultValue"]
                    ["ObjectSearchResult"]["Objects"]["MemberSuiteObject"])
         else:
             return None
+
+    def convert_ms_object(self, ms_object):
+        """
+        Converts the list of dictionaries with keys "key" and "value" into
+        more logical value-key pairs in a plain dictionary.
+        """
+        out_dict = {}
+        for item in ms_object:
+            out_dict[item["Key"]] = item["Value"]
+        return out_dict

--- a/membersuite-api-client/tests.py
+++ b/membersuite-api-client/tests.py
@@ -84,5 +84,29 @@ class ConciergeClientTestCase(unittest.TestCase):
         response = client.query_orgs(parameters, since_when)
         self.assertFalse(response)
 
+    def test_convert_ms_object(self):
+        """
+        Can we parse the list of dicts for org attributes into a dict?
+        """
+        client = ConciergeClient(access_key=MS_ACCESS_KEY,
+                                 secret_key=MS_SECRET_KEY,
+                                 association_id=MS_ASSOCIATION_ID)
+
+        # Send a login request to receive a session id
+        session_id = client.request_session()
+        self.assertTrue(session_id)
+        parameters = {
+            'Name': 'AASHE Test Campus',
+        }
+        response = client.query_orgs(parameters)
+        self.assertEqual(response[0]["Fields"]["KeyValueOfstringanyType"]
+                         [28]["Value"],
+                         'AASHE Test Campus')
+        converted_dict = client.convert_ms_object(
+            response[0]["Fields"]["KeyValueOfstringanyType"])
+
+        self.assertEqual(converted_dict["Name"], "AASHE Test Campus")
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Added generic method to turn the list of attributes of an object returned from an API method into a dictionary.

Some attributes will still be complex and require further processing, but that can be localized (or you can call this same method again and pass just that field as the argument).