### PR TITLE
Refactor some ConciergeClient methods into utils module

### DIFF
--- a/membersuite_api_client/client.py
+++ b/membersuite_api_client/client.py
@@ -40,6 +40,8 @@ class ConciergeClient(object):
         return base64.b64encode(hashed).decode("utf-8")
 
     def get_session_id_from_login_result(self, login_result):
+        # @TODO this should be renamed and moved to utils.py.
+        # rename to `get_session_id_from_api_response`
         try:
             return login_result["header"]["header"]["SessionId"]
         except TypeError:
@@ -62,7 +64,7 @@ class ConciergeClient(object):
 
         if not self.session_id:
             raise MembersuiteLoginError(
-                result["body"]["LoginResult"]["Errors"])
+                result["body"]["WhoAmIResult"]["Errors"])
 
         return self.session_id
 
@@ -134,16 +136,6 @@ class ConciergeClient(object):
                    ["ObjectSearchResult"]["Objects"]["MemberSuiteObject"])
         else:
             return None
-
-    def convert_ms_object(self, ms_object):
-        """
-        Converts the list of dictionaries with keys "key" and "value" into
-        more logical value-key pairs in a plain dictionary.
-        """
-        out_dict = {}
-        for item in ms_object:
-            out_dict[item["Key"]] = item["Value"]
-        return out_dict
 
     def runSQL(self, query, start_record=0):
         concierge_request_header = self.construct_concierge_header(

--- a/membersuite_api_client/client.py
+++ b/membersuite_api_client/client.py
@@ -4,6 +4,9 @@ from zeep import Client
 import base64
 import hmac
 
+from .utils import get_session_id
+
+
 XHTML_NAMESPACE = "http://membersuite.com/schemas"
 
 
@@ -39,14 +42,6 @@ class ConciergeClient(object):
         hashed = hmac.new(secret_b, data_b, sha1).digest()
         return base64.b64encode(hashed).decode("utf-8")
 
-    def get_session_id_from_login_result(self, login_result):
-        # @TODO this should be renamed and moved to utils.py.
-        # rename to `get_session_id_from_api_response`
-        try:
-            return login_result["header"]["header"]["SessionId"]
-        except TypeError:
-            return None
-
     def request_session(self):
         """
         Performs initial request to initialize session and get session id
@@ -59,8 +54,7 @@ class ConciergeClient(object):
         result = self.client.service.WhoAmI(
             _soapheaders=[concierge_request_header])
 
-        self.session_id = self.get_session_id_from_login_result(
-            login_result=result)
+        self.session_id = get_session_id(result=result)
 
         if not self.session_id:
             raise MembersuiteLoginError(

--- a/membersuite_api_client/subscriptions/services.py
+++ b/membersuite_api_client/subscriptions/services.py
@@ -17,6 +17,7 @@
 """
 
 from .models import Subscription
+from ..utils import convert_ms_object
 
 
 class SubscriptionService(object):
@@ -48,7 +49,7 @@ class SubscriptionService(object):
 
             subscription_list = []
             for obj in objects:
-                sane_obj = self.client.convert_ms_object(
+                sane_obj = convert_ms_object(
                     obj['Fields']['KeyValueOfstringanyType'])
                 subscription = Subscription(
                     id=sane_obj['ID'],

--- a/membersuite_api_client/tests/test_client.py
+++ b/membersuite_api_client/tests/test_client.py
@@ -5,8 +5,6 @@ from ..client import ConciergeClient
 import datetime
 
 
-MS_USER_ID = os.environ.get("MS_USER_ID", None)
-MS_USER_PASS = os.environ.get("MS_USER_PASS", None)
 MS_ACCESS_KEY = os.environ["MS_ACCESS_KEY"]
 MS_SECRET_KEY = os.environ["MS_SECRET_KEY"]
 MS_ASSOCIATION_ID = os.environ["MS_ASSOCIATION_ID"]
@@ -83,29 +81,6 @@ class ConciergeClientTestCase(unittest.TestCase):
         since_when = datetime.date.today() - datetime.timedelta(1)
         response = client.query_orgs(parameters, since_when)
         # self.assertFalse(response)
-
-    def test_convert_ms_object(self):
-        """
-        Can we parse the list of dicts for org attributes into a dict?
-        """
-        client = ConciergeClient(access_key=MS_ACCESS_KEY,
-                                 secret_key=MS_SECRET_KEY,
-                                 association_id=MS_ASSOCIATION_ID)
-
-        # Send a login request to receive a session id
-        session_id = client.request_session()
-        self.assertTrue(session_id)
-        parameters = {
-            'Name': 'AASHE Test Campus',
-        }
-        response = client.query_orgs(parameters)
-        self.assertEqual(response[0]["Fields"]["KeyValueOfstringanyType"]
-                         [28]["Value"],
-                         'AASHE Test Campus')
-        converted_dict = client.convert_ms_object(
-            response[0]["Fields"]["KeyValueOfstringanyType"])
-
-        self.assertEqual(converted_dict["Name"], "AASHE Test Campus")
 
 
 if __name__ == '__main__':

--- a/membersuite_api_client/tests/test_client.py
+++ b/membersuite_api_client/tests/test_client.py
@@ -1,8 +1,9 @@
+import datetime
 import os
 import unittest
 
 from ..client import ConciergeClient
-import datetime
+from ..utils import get_session_id
 
 
 MS_ACCESS_KEY = os.environ["MS_ACCESS_KEY"]
@@ -53,9 +54,8 @@ class ConciergeClientTestCase(unittest.TestCase):
         # Check that the session ID in the response headers matches the
         # previously obtained session, so the user was not re-authenticated
         # but properly used the established session.
-        self.assertEqual(
-            client.get_session_id_from_login_result(login_result=response),
-            client.session_id)
+        self.assertEqual(get_session_id(result=response),
+                         client.session_id)
 
     def test_query_orgs(self):
         """

--- a/membersuite_api_client/tests/test_utils.py
+++ b/membersuite_api_client/tests/test_utils.py
@@ -1,0 +1,40 @@
+import os
+import unittest
+
+from ..client import ConciergeClient
+from ..utils import convert_ms_object
+
+
+MS_ACCESS_KEY = os.environ["MS_ACCESS_KEY"]
+MS_SECRET_KEY = os.environ["MS_SECRET_KEY"]
+MS_ASSOCIATION_ID = os.environ["MS_ASSOCIATION_ID"]
+
+
+class UtilsTestCase(unittest.TestCase):
+
+    def test_convert_ms_object(self):
+        """
+        Can we parse the list of dicts for org attributes into a dict?
+        """
+        client = ConciergeClient(access_key=MS_ACCESS_KEY,
+                                 secret_key=MS_SECRET_KEY,
+                                 association_id=MS_ASSOCIATION_ID)
+
+        # Send a login request to receive a session id
+        session_id = client.request_session()
+        self.assertTrue(session_id)
+        parameters = {
+            'Name': 'AASHE Test Campus',
+        }
+        response = client.query_orgs(parameters)
+        self.assertEqual(response[0]["Fields"]["KeyValueOfstringanyType"]
+                         [28]["Value"],
+                         'AASHE Test Campus')
+        converted_dict = convert_ms_object(
+            response[0]["Fields"]["KeyValueOfstringanyType"])
+
+        self.assertEqual(converted_dict["Name"], "AASHE Test Campus")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/membersuite_api_client/utils.py
+++ b/membersuite_api_client/utils.py
@@ -7,3 +7,14 @@ def convert_ms_object(ms_object):
     for item in ms_object:
         out_dict[item["Key"]] = item["Value"]
     return out_dict
+
+
+def get_session_id(result):
+    """Returns the Session ID for an API result.
+
+    When there's no Session ID, returns None.
+    """
+    try:
+        return result["header"]["header"]["SessionId"]
+    except TypeError:
+        return None

--- a/membersuite_api_client/utils.py
+++ b/membersuite_api_client/utils.py
@@ -1,0 +1,9 @@
+def convert_ms_object(ms_object):
+    """
+    Converts the list of dictionaries with keys "key" and "value" into
+    more logical value-key pairs in a plain dictionary.
+    """
+    out_dict = {}
+    for item in ms_object:
+        out_dict[item["Key"]] = item["Value"]
+    return out_dict


### PR DESCRIPTION
Move ConciergeClient.convert_ms_object() to new utils module.

Move ConciergeClient.get_session_id_from_login_result() to utils module and rename to get_session_id().

Talked this over with Ben; he approves.